### PR TITLE
Certificate Management with Lets Encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,4 @@ AWS_ACCESS_KEY_ID=$(vault kv get -mount=homelab -field=terraform_access_key wasa
 * Packer templates based on work by [Julien Brochet](https://github.com/aerialls/madalynn-packer)
 * Terraform provider for Proxmox by [Telmate](https://registry.terraform.io/providers/Telmate/proxmox)
 * Ceph Ansible code taken and consolidated from [peacedata0](https://github.com/peacedata0/proxmox-ansible-1)
+* Synology Certs Role by [JohnVillalovos](https://github.com/JohnVillalovos/synology_certs)

--- a/ansible/certs/deploy_certs.yml
+++ b/ansible/certs/deploy_certs.yml
@@ -1,0 +1,167 @@
+---
+- name: Deploy certificates
+  hosts: netbox, minecraft, pdns, proxmox, pihole, plex, synology, vault
+  become: true
+
+  vars:
+    wildcard_cert: "{{ lookup('hashi_vault', 'secret=homelab/data/certificates').cert }}"
+    wildcard_chain: "{{ lookup('hashi_vault', 'secret=homelab/data/certificates').chain }}"
+    wildcard_fullchain: "{{ lookup('hashi_vault', 'secret=homelab/data/certificates').fullchain }}"
+    wildcard_privkey: "{{ lookup('hashi_vault', 'secret=homelab/data/certificates').privkey }}"
+  
+  tasks:
+    - name: Install certs to netbox
+      block:
+        - name: set content of Netbox certificate and key
+          ansible.builtin.copy:
+            dest: "{{ item.dest }}"
+            content: "{{ item.content }}"
+          with_items:
+            - { dest: "/etc/ssl/certs/netbox.crt", content: "{{ wildcard_cert }}" }
+            - { dest: "/etc/ssl/private/netbox.key", content: "{{ wildcard_privkey }}" }
+          notify: restart nginx
+          no_log: true
+      when: inventory_hostname in groups['netbox']
+
+    - name: Install certs to minecraft
+      block:
+        - name: set contents of minecraft certificate and key
+          ansible.builtin.copy:
+            dest: "{{ item.dest }}"
+            content: "{{ item.content }}"
+          with_items:
+            - { dest: "/etc/ssl/certs/wildcard.lan.pezlab.dev-certificate.pem", content: "{{ wildcard_cert }}" }
+            - { dest: "/etc/ssl/private/wildcard.lan.pezlab.dev-private_key.pem", content: "{{ wildcard_privkey }}" }
+          no_log: true
+          notify: restart nginx
+      when: inventory_hostname in groups['minecraft']
+    
+    - name: Install certs to powerdns
+      block:
+        - name: set contents of pdns certificate and key
+          ansible.builtin.copy:
+            dest: "{{ item.dest }}"
+            content: "{{ item.content }}"
+          with_items:
+            - { dest: "/etc/ssl/certs/wildcard.lan.pezlab.dev-certificate.pem", content: "{{ wildcard_cert }}" }
+            - { dest: "/etc/ssl/private/wildcard.lan.pezlab.dev-private_key.pem", content: "{{ wildcard_privkey }}" }
+          no_log: true
+          notify: restart nginx
+      when: inventory_hostname in groups['pdns']
+
+    - name: Deploy certs to Proxmox
+      block:
+        - name: set contents of Proxmox node's certificate and key
+          ansible.builtin.copy:
+            dest: "{{ item.dest }}"
+            content: "{{ item.content }}"
+          with_items:
+            - { dest: "/etc/pve/local/pve-ssl.pem", content: "{{ wildcard_cert }}" }
+            - { dest: "/etc/pve/local/pve-ssl.key", content: "{{ wildcard_privkey }}" }
+          no_log: true
+          notify: restart pveproxy
+      when: inventory_hostname in groups['proxmox']
+    
+    - name: Deploy certs to Pihole
+      block:
+        - name: set contents of Pihole's certificate and key
+          ansible.builtin.copy:
+            dest: "{{ item.dest }}"
+            content: "{{ item.content }}"
+          with_items:
+            - { dest: "/etc/lighttpd/server.pem", content: "{{ wildcard_privkey }}{{ wildcard_cert }}" }
+          no_log: true
+          notify: restart lighttpd
+      when: inventory_hostname in groups['pihole']
+
+    - name: Install certs to plex
+      block:
+        - name: set contents of plex certificate and key
+          ansible.builtin.copy:
+            dest: "{{ item.dest }}"
+            content: "{{ item.content }}"
+          with_items:
+            - { dest: "/etc/ssl/certs/wildcard.lan.pezlab.dev-certificate.pem", content: "{{ wildcard_cert }}" }
+            - { dest: "/etc/ssl/private/wildcard.lan.pezlab.dev-private_key.pem", content: "{{ wildcard_privkey }}" }
+          no_log: true
+          notify: restart nginx
+      when: inventory_hostname in groups['plex']
+
+    - name: Install certs to Synology
+      block:
+        - name: Copy up print certs to remote site
+          ansible.builtin.copy:
+            dest: "~/"
+            src: print-certs.py
+            mode: 0700
+            owner: pezhore
+            group: users
+        
+        - name: Find nginx certificates using script
+          shell: "~/print-certs.py nginx -t *.lan.pezlab.dev -a"
+          register: find_nginx_certs
+        
+        # This is annoying...
+        - name: Set the contents of our Certificate
+          ansible.builtin.copy:
+            dest: "{{ item.0.split('::')[1] }}/{{ item.1 }}"
+            content: "{{ wildcard_cert }}"
+          with_nested:
+            - "{{ find_nginx_certs.stdout_lines }}"
+            - [ 'cert.pem' ]
+
+        - name: Set the contents of our Chain
+          ansible.builtin.copy:
+            dest: "{{ item.0.split('::')[1] }}/{{ item.1 }}"
+            content: "{{ wildcard_chain }}"
+          with_nested:
+            - "{{ find_nginx_certs.stdout_lines }}"
+            - [ 'chain.pem' ]
+
+        - name: Set the contents of our Fullchain
+          ansible.builtin.copy:
+            dest: "{{ item.0.split('::')[1] }}/{{ item.1 }}"
+            content: "{{ wildcard_fullchain }}"
+          with_nested:
+            - "{{ find_nginx_certs.stdout_lines }}"
+            - [ 'fullchain.pem' ]
+
+        - name: Set the contents of our private key
+          ansible.builtin.copy:
+            dest: "{{ item.0.split('::')[1] }}/{{ item.1 }}"
+            content: "{{ wildcard_privkey }}"
+          with_nested:
+            - "{{ find_nginx_certs.stdout_lines }}"
+            - [ 'privkey.pem' ]
+      notify: restart nginx
+      when: inventory_hostname in groups['synology']
+
+    - name: Install certs to Vault
+      block:
+        - name: set contents of Vault certificate and key
+          ansible.builtin.copy:
+            dest: "{{ item.dest }}"
+            content: "{{ item.content }}"
+          with_items:
+            - { dest: "/etc/ssl/certs/vault.pezlab.local.cer", content: "{{ wildcard_cert }}" }
+            - { dest: "/etc/ssl/private/vault.pezlab.local.key", content: "{{ wildcard_privkey }}" }
+          no_log: true
+          notify: restart nginx
+      when: inventory_hostname in groups['vault']
+
+  handlers:
+    - name: restart nginx
+      ansible.builtin.systemd:
+        name: nginx
+        state: restarted
+        enabled: yes
+    
+    - name: restart pveproxy
+      service:
+        name: pveproxy
+        state: restarted
+
+    - name: restart lighttpd
+      service:
+        name: lighttpd
+        state: restarted

--- a/ansible/certs/files/print-certs.py
+++ b/ansible/certs/files/print-certs.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# vim: ai ts=4 sts=4 et sw=4
+
+# Copyright (c) 2018 John L. Villalovos
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import argparse
+import os
+import subprocess
+import sys
+
+# This is based on using Synology DiskStation Manager (DSM) 6.1. Unsure if it
+# works on previous versions. At the time of writing this (5-Mar-2018) I was
+# using "DSM 6.1.5-15254 Update 1"
+
+# Directory where certificates used by NGINX are stored
+SYNOLOGY_NGINX_CERTS_DIR = os.path.abspath("/usr/syno/etc/certificate")
+# Directory where certificates used by various packages are stored.
+SYNOLOGY_PACKAGES_CERTS_DIR = os.path.abspath("/usr/local/etc/certificate")
+
+
+def main():
+    args = parse_args()
+
+    # Adding two parameters to limit our results:
+    # target: The CN expected (whether it's synology.com or a wildcard cert path)
+    # allcerts: When specified all certificates found are returned, when omitted the
+    #           _archive folder is excluded from output
+    target = args.target
+    allcerts = args.allcerts
+    
+    if args.mode == 'nginx':
+        get_certificates(SYNOLOGY_NGINX_CERTS_DIR, allcerts, target)
+    elif args.mode == "packages":
+        get_certificates(SYNOLOGY_PACKAGES_CERTS_DIR, allcerts, target)
+    else:
+        sys.exit("Unknown mode: {}".format(args.mode))
+
+
+def get_certificates(dirname, allcerts, target):
+    if not os.path.isdir(dirname):
+        sys.exit("The certificate directory does not exist: {}".format(
+            dirname))
+
+    for package_name in sorted(os.listdir(dirname)):
+        service_dir = os.path.join(dirname, package_name)
+        if not os.path.isdir(service_dir):
+            continue
+
+        for (dirpath, dirnames, filenames) in os.walk(service_dir):
+            
+            # If we are looking for all certificates, don't filter our dirpaths
+            if allcerts:
+               if 'cert.pem' in filenames:
+                    
+                    full_path = os.path.join(dirpath, 'cert.pem')
+                    host_name = find_cert_host(full_path)
+                    
+                    # Logic to determine if we're looking for a specific hostname
+                    if target is None: 
+                        print("{}::{}::{}".format(host_name, dirpath, package_name))
+                    elif target == host_name:
+                        print("{}::{}::{}".format(host_name, dirpath, package_name))
+            else:
+                # Exclude the _archive directory from the output
+                if "_archive" not in dirpath:
+                    if 'cert.pem' in filenames:
+                        
+                        full_path = os.path.join(dirpath, 'cert.pem')
+                        host_name = find_cert_host(full_path)
+                        
+                        # Logic to determine if we're looking for a specific hostname
+                        if target is None: 
+                            print("{}::{}::{}".format(host_name, dirpath, package_name))
+                        elif target == host_name:
+                            print("{}::{}::{}".format(host_name, dirpath, package_name))    
+
+
+def find_cert_host(filename):
+    cmd_line = ['openssl', 'x509', '-noout', '-subject', '-in', filename]
+    stdout = subprocess.check_output(cmd_line, universal_newlines=True)
+    # The previous format was: "subject=CN = hostname.example.com", however in 
+    # DSM 7.x, it appears more information was tacked on after 'subject=' causing the
+    # previous code to fail. Here we just split on 'CN = '
+    _, host_name = stdout.split('CN =', 1)
+    host_name = host_name.strip()
+    return host_name
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('mode', choices=['nginx', 'packages'], help='Mode limiting certificate search path. Can be either nginx or packages')
+    parser.add_argument('-t', '--target', help='Target CN to find. This is helpful as there may be multiple certificates on a single host')
+    parser.add_argument('-a', '--allcerts', action='store_true', help='Switch that will find all certificates. When omitted, the archived certs are not returned.')
+    args = parser.parse_args()
+    return args
+
+
+if '__main__' == __name__:
+    sys.exit(main())

--- a/ansible/certs/renew-wildcard.yml
+++ b/ansible/certs/renew-wildcard.yml
@@ -1,6 +1,6 @@
 ---
 - name: Deal with Certbot and Lets Encrypt
-  hosts: netbox.lan.pezlab.dev #all
+  hosts: netbox.lan.pezlab.dev
   become: true
 
   vars:

--- a/ansible/certs/renew-wildcard.yml
+++ b/ansible/certs/renew-wildcard.yml
@@ -1,0 +1,82 @@
+---
+- name: Deal with Certbot and Lets Encrypt
+  hosts: netbox.lan.pezlab.dev #all
+  become: true
+
+  vars:
+    initial_setup: false
+    force: true
+    push_certs: true
+
+  tasks:
+    - name: Initial Setup on netbox only
+      block:
+        - name: Ensure the /root/.secrets directory exists
+          ansible.builtin.file:
+            path: /root/.secrets
+            state: directory
+            mode: 0700
+
+        - name: Create the /root/.secrets/cloudflare.ini file with content from vault
+          ansible.builtin.copy:
+            dest: /root/.secrets/cloudflare.ini
+            content: |
+              dns_cloudflare_email = "{{ lookup('hashi_vault', 'secret=homelab/data/services/cloudflare').email}}"
+              dns_cloudflare_api_key = "{{ lookup('hashi_vault', 'secret=homelab/data/services/cloudflare').global_api}}"
+            mode: 0440
+
+        - name: Install software properties
+          ansible.builtin.apt:
+            name: software-properties-common
+            state: present
+            update_cache: yes
+        
+        - name: Install Certbot
+          ansible.builtin.apt:
+            name: "{{ item }}"
+            state: present
+            update_cache: yes
+          with_items:
+            - certbot
+            - python3-certbot-dns-cloudflare
+        
+        - name: Execute command to do the dns thing
+          ansible.builtin.command: certbot certonly --dns-cloudflare --dns-cloudflare-credentials /root/.secrets/cloudflare.ini -d *.lan.pezlab.dev --preferred-challenges dns-01 --non-interactive --agree-tos -m "{{ lookup('hashi_vault', 'secret=homelab/data/services/cloudflare').email}}"
+          register: certbot
+        
+        - name: debug output
+          debug:
+            msg: "{{ certbot.stdout }}"
+            
+        - name: Slurp up the cert
+          ansible.builtin.slurp:
+            src: /etc/letsencrypt/live/lan.pezlab.dev/cert.pem
+          register: cert
+        
+        - name: Slurp up the chain
+          ansible.builtin.slurp:
+            src: /etc/letsencrypt/live/lan.pezlab.dev/chain.pem
+          register: chain
+        
+        - name: Slurp up the fullchain
+          ansible.builtin.slurp:
+            src: /etc/letsencrypt/live/lan.pezlab.dev/fullchain.pem
+          register: fullchain
+        
+        - name: Slurp up the privkey
+          ansible.builtin.slurp:
+            src: /etc/letsencrypt/live/lan.pezlab.dev/privkey.pem
+          register: privkey
+
+        - name: Push content of certs to vault
+          community.hashi_vault.vault_write:
+              path: homelab/data/certificates
+              data:
+                data:
+                  cert: "{{ cert.content | b64decode }}"
+                  chain: "{{ chain.content | b64decode }}"
+                  fullchain: "{{ fullchain.content | b64decode }}"
+                  privkey: "{{ privkey.content | b64decode }}"
+          become: false
+          delegate_to: localhost
+      when: inventory_hostname == "netbox.lan.pezlab.dev"


### PR DESCRIPTION
This handles certificate renewal/deployment in the homelab (heavily relying on Vault for secrets/certificate storage).

The idea is to run the `renew-wildcard.yml` when the time comes to trigger the LetsEncrypt renewal/push to Vault, followed by the `deploy_certs.yml` to push to the various homelab systems.

It does require a more comprehensive inventory - including systems that are exclusively provisioned by Terraform (e.g. pihole, synology, etc).

And there's a few more things that require effort - my Ubiquiti Cloud Key for one, but that's a PR for a different time.